### PR TITLE
update pytest hooks

### DIFF
--- a/src/pytest_timestamper/plugin.py
+++ b/src/pytest_timestamper/plugin.py
@@ -35,7 +35,7 @@ class TimestamperTerminalReporter(TerminalReporter):
         return self._cache[key]
 
 
-@pytest.mark.trylast
+@pytest.hookimpl(trylast=True)
 def pytest_configure(config: Config) -> None:
     if config.pluginmanager.has_plugin("terminalreporter"):
         reporter = config.pluginmanager.get_plugin("terminalreporter")


### PR DESCRIPTION
There was a warning being emitted from pytest about upcoming deprecations for this mark (https://docs.pytest.org/en/stable/deprecations.html#configuring-hook-specs-impls-using-markers)

This PR updates to use the hooks